### PR TITLE
Minor fixes to enable compilation on MacOSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ add_library(${PROJECT_NAME} SHARED
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -fopenmp -DNDEBUG")
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  string(REPLACE "-fopenmp" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+endif()
+
 if(ANDROID)
   set(LIB_ONLY ON)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

--- a/lib/TH/THDiskFile.c
+++ b/lib/TH/THDiskFile.c
@@ -31,6 +31,7 @@ const char *THDiskFile_name(THFile *self)
 
 /* workaround mac osx lion ***insane*** fread bug */
 #ifdef __APPLE__
+#define THMin(X, Y)  ((X) < (Y) ? (X) : (Y))
 size_t fread__(void *ptr, size_t size, size_t nitems, FILE *stream)
 {
   size_t nread = 0;


### PR DESCRIPTION
These commits fix compilation on MacOSX.

Definition of `THMin` was missing (must have been stripped out from the original `torch/TH` package) so I added the macro definition of `THMin` found in `torch/TH/THGeneral.h.in`.

OpenMP is only supported through custom compilers on MacOSX. So I removed the flag based on `CMAKE_SYSTEM_NAME`. (`if(APPLE)` might be simpler, but I don't know whether this applies to all apple machines)