### PR TITLE
implement parallel translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### New features
 
-* Implement parallel translation
 * Add 16 bits quantization with SSE and AVX2 optimizations
 * Introduce vocabulary mapping to speed-up decoding-up
 * Report profiles per modules block (encoder_fwd, encoder_bwd, decoder, generator)
 * Support cloning a `Translator` while sharing the model data
+* Translate batches in parallel via `cli/translate`
 
 ### Fixes and improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New features
 
+* Implement parallel translation
 * Add 16 bits quantization with SSE and AVX2 optimizations
 * Introduce vocabulary mapping to speed-up decoding-up
 * Report profiles per modules block (encoder_fwd, encoder_bwd, decoder, generator)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ CTranslate also bundles OpenNMT's [Tokenizer](https://github.com/OpenNMT/Tokeniz
   * otherwise, select a recent [SIMD extensions](https://gcc.gnu.org/onlinedocs/gcc-5.5.0/gcc/x86-Options.html#x86-Options) to improve performance while meeting portability requirements.
 * Consider installing [Intel® MKL](https://software.intel.com/en-us/intel-mkl) when you are targetting Intel®-powered platforms. If found, the project will automatically link against it.
 * Consider using quantization options as described above.
-* Parallel translation launch parallel translation process, each translation handling `batch` sentences in parallel - while when using `threads` you enable each translator to use multiple threads. If you want to have optimal global throughput for a collection of sentence, favor `parallel` with `thread` to 1. If you want to have optimal response time for a single batch, set `parallel` to 1, and increase `thread`.
+* When using `cli/translate`, consider fine-tuning the level of parallelism:
+  * the `--parallel` option enables concurrent translation of `--batch_size` sentences
+  * the `--threads` option enables each translation to use multiple threads
+  * *Bottom-line:* if you want optimal throughput for a collection of sentences, increase `--parallel` and set `--threads` to 1; if you want minimal latency for a single batch, set `--parallel` to 1, and increase `--threads`.
 
 ## Using
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ CTranslate also bundles OpenNMT's [Tokenizer](https://github.com/OpenNMT/Tokeniz
   * otherwise, select a recent [SIMD extensions](https://gcc.gnu.org/onlinedocs/gcc-5.5.0/gcc/x86-Options.html#x86-Options) to improve performance while meeting portability requirements.
 * Consider installing [Intel® MKL](https://software.intel.com/en-us/intel-mkl) when you are targetting Intel®-powered platforms. If found, the project will automatically link against it.
 * Consider using quantization options as described above.
+* Parallel translation launch parallel translation process, each translation handling `batch` sentences in parallel - while when using `threads` you enable each translator to use multiple threads. If you want to have optimal global throughput for a collection of sentence, favor `parallel` with `thread` to 1. If you want to have optimal response time for a single batch, set `parallel` to 1, and increase `thread`.
 
 ## Using
 

--- a/cli/Batch.h
+++ b/cli/Batch.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class Batch
+{
+  public:
+    Batch():_id(0) {}
+    Batch(const std::vector<std::string> &data, int id):_data(data), _id(id) {}
+    size_t size() const { return _data.size(); }
+    bool empty() const { return _data.empty(); }
+    const std::vector<std::string> &get_data() const { return _data; }
+    size_t get_id() const { return _id; }
+  private:
+    std::vector<std::string> _data;
+    size_t _id;
+};

--- a/cli/Batch.h
+++ b/cli/Batch.h
@@ -5,14 +5,34 @@
 
 class Batch
 {
-  public:
-    Batch():_id(0) {}
-    Batch(const std::vector<std::string> &data, int id):_data(data), _id(id) {}
-    size_t size() const { return _data.size(); }
-    bool empty() const { return _data.empty(); }
-    const std::vector<std::string> &get_data() const { return _data; }
-    size_t get_id() const { return _id; }
-  private:
-    std::vector<std::string> _data;
-    size_t _id;
+public:
+  Batch(const std::vector<std::string>& data, size_t id)
+    : _data(data)
+    , _id(id)
+  {
+  }
+
+  size_t size() const
+  {
+    return _data.size();
+  }
+
+  bool empty() const
+  {
+    return _data.empty();
+  }
+
+  const std::vector<std::string>& get_data() const
+  {
+    return _data;
+  }
+
+  size_t get_id() const
+  {
+    return _id;
+  }
+
+private:
+  std::vector<std::string> _data;
+  size_t _id;
 };

--- a/cli/BatchReader.cc
+++ b/cli/BatchReader.cc
@@ -12,16 +12,18 @@ BatchReader::BatchReader(const std::string& file, size_t batch_size)
 BatchReader::BatchReader(std::istream& in, size_t batch_size)
   : _in(in)
   , _batch_size(batch_size)
+  , _batch_id(0)
+  , _read_size(0)
 {
 }
 
 Batch BatchReader::read_next()
 {
-  std::lock_guard<std::mutex> lock(_readerMutex);
+  std::lock_guard<std::mutex> lock(_reader_mutex);
   std::vector<std::string> batch;
 
   if (_in.eof())
-    return Batch();
+    return Batch(batch, ++_batch_id);
 
   batch.reserve(_batch_size);
 

--- a/cli/BatchReader.cc
+++ b/cli/BatchReader.cc
@@ -5,7 +5,7 @@ BatchReader::BatchReader(const std::string& file, size_t batch_size)
   , _in(_file)
   , _batch_size(batch_size)
   , _batch_id(0)
-  , _read_size(0)
+  , _read_lines(0)
 {
 }
 
@@ -13,7 +13,7 @@ BatchReader::BatchReader(std::istream& in, size_t batch_size)
   : _in(in)
   , _batch_size(batch_size)
   , _batch_id(0)
-  , _read_size(0)
+  , _read_lines(0)
 {
 }
 
@@ -31,7 +31,7 @@ Batch BatchReader::read_next()
   while (batch.size() < _batch_size && std::getline(_in, line))
     batch.push_back(line);
 
-  _read_size += batch.size();
+  _read_lines += batch.size();
 
   return Batch(batch, ++_batch_id);
 }

--- a/cli/BatchReader.h
+++ b/cli/BatchReader.h
@@ -12,13 +12,17 @@ public:
   BatchReader(std::istream& in, size_t batch_size);
 
   Batch read_next();
-  size_t size() const { return _read_size; }
+
+  size_t read_lines() const
+  {
+    return _read_lines;
+  }
 
 private:
   std::ifstream _file;
   std::istream& _in;
   size_t _batch_size;
   size_t _batch_id;
-  size_t _read_size;
+  size_t _read_lines;
   std::mutex _reader_mutex;
 };

--- a/cli/BatchReader.h
+++ b/cli/BatchReader.h
@@ -11,7 +11,6 @@ public:
   BatchReader(const std::string& file, size_t batch_size);
   BatchReader(std::istream& in, size_t batch_size);
 
-  /* read batches thread-sage sequentially vector and batch id */
   Batch read_next();
   size_t size() const { return _read_size; }
 
@@ -21,6 +20,5 @@ private:
   size_t _batch_size;
   int _batch_id;
   size_t _read_size;
-  std::mutex _readerMutex;
-
+  std::mutex _reader_mutex;
 };

--- a/cli/BatchReader.h
+++ b/cli/BatchReader.h
@@ -18,7 +18,7 @@ private:
   std::ifstream _file;
   std::istream& _in;
   size_t _batch_size;
-  int _batch_id;
+  size_t _batch_id;
   size_t _read_size;
   std::mutex _reader_mutex;
 };

--- a/cli/BatchReader.h
+++ b/cli/BatchReader.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <fstream>
-#include <string>
-#include <vector>
+#include <mutex>
+
+#include "Batch.h"
 
 class BatchReader
 {
@@ -10,10 +11,16 @@ public:
   BatchReader(const std::string& file, size_t batch_size);
   BatchReader(std::istream& in, size_t batch_size);
 
-  std::vector<std::string> read_next();
+  /* read batches thread-sage sequentially vector and batch id */
+  Batch read_next();
+  size_t size() const { return _read_size; }
 
 private:
   std::ifstream _file;
   std::istream& _in;
   size_t _batch_size;
+  int _batch_id;
+  size_t _read_size;
+  std::mutex _readerMutex;
+
 };

--- a/cli/BatchWriter.cc
+++ b/cli/BatchWriter.cc
@@ -3,6 +3,7 @@
 BatchWriter::BatchWriter(const std::string& file)
   : _file(file.c_str())
   , _out(_file)
+  , _last_batch_id(0)
 {
 }
 
@@ -11,8 +12,29 @@ BatchWriter::BatchWriter(std::ostream& out)
 {
 }
 
-void BatchWriter::write(const std::vector<std::string>& batch)
+void BatchWriter::write(const Batch& batch)
 {
-  for (const auto& sent: batch)
-    _out << sent << std::endl;
+  std::lock_guard<std::mutex> lock(_writerMutex);
+  size_t batch_id = batch.get_id();
+  if (!batch_id)
+    return;
+  if (batch_id == _last_batch_id+1)
+  {
+    std::vector<std::string> v = batch.get_data();
+    while (batch_id == _last_batch_id + 1) {
+      for (const auto& sent: v)
+        _out << sent << std::endl;
+      _last_batch_id = batch_id;
+      auto it = _pending_batches.find(_last_batch_id + 1);
+      if (it != _pending_batches.end())
+      {
+        v = it -> second;
+        batch_id = _last_batch_id + 1;
+        _pending_batches.erase(it);
+      }
+    }
+  }
+  else
+    _pending_batches[batch_id] = batch.get_data();
+
 }

--- a/cli/BatchWriter.h
+++ b/cli/BatchWriter.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <fstream>
-#include <string>
-#include <vector>
+#include <mutex>
+#include <map>
+
+#include "Batch.h"
 
 class BatchWriter
 {
@@ -10,9 +12,13 @@ public:
   BatchWriter(const std::string& file);
   BatchWriter(std::ostream& out);
 
-  void write(const std::vector<std::string>& batch);
+  void write(const Batch& batch);
 
 private:
   std::ofstream _file;
   std::ostream& _out;
+  std::map<size_t, std::vector<std::string>> _pending_batches;
+  size_t _last_batch_id;
+  std::mutex _writerMutex;
+
 };

--- a/cli/BatchWriter.h
+++ b/cli/BatchWriter.h
@@ -19,6 +19,5 @@ private:
   std::ostream& _out;
   std::map<size_t, std::vector<std::string>> _pending_batches;
   size_t _last_batch_id;
-  std::mutex _writerMutex;
-
+  std::mutex _writer_mutex;
 };

--- a/cli/translate.cc
+++ b/cli/translate.cc
@@ -115,7 +115,7 @@ int main(int argc, char* argv[])
   {
     t2 = std::chrono::high_resolution_clock::now();
     std::chrono::duration<float> sec = t2 - t1;
-    size_t num_sents = reader->size();
+    size_t num_sents = reader->read_lines();
     std::cerr << "avg real (sentence/s)\t" << sec.count() / num_sents << std::endl;
   }
 


### PR DESCRIPTION
new option `parallel` running parallel translation at the batch level - can combine with `--threads` - minimal benchmark show x2.5 speed-up on top of fastest configuration using 4 parallels.