### PR TITLE
Support Translator shared cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add 16 bits quantization with SSE and AVX2 optimizations
 * Introduce vocabulary mapping to speed-up decoding-up
 * Report profiles per modules block (encoder_fwd, encoder_bwd, decoder, generator)
+* Support cloning a `Translator` while sharing the model data
 
 ### Fixes and improvements
 

--- a/include/onmt/Model.h
+++ b/include/onmt/Model.h
@@ -13,10 +13,11 @@ namespace onmt
   class Model
   {
   public:
-    Model(const std::string& filename, Profiler& profiler, bool cuda, bool qlinear);
+    Model(const std::string& filename);
 
-    nn::Module<MatFwd>* get_encoder_module(size_t index);
-    nn::Module<MatFwd>* get_decoder_module(size_t index);
+    void create_graph(nn::ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory,
+                      std::vector<nn::Module<MatFwd>*>& encoder,
+                      std::vector<nn::Module<MatFwd>*>& decoder);
 
     const Dictionary& get_src_dict() const;
     const Dictionary& get_tgt_dict() const;
@@ -29,22 +30,17 @@ namespace onmt
     template <typename T = double>
     T get_option_value(const std::string& key, T default_value = 0) const;
 
-    void enable_profiling();
-
   private:
-    nn::Module<MatFwd>* get_module(size_t index, std::vector<nn::Module<MatFwd>*>& modules);
-
     void load_options(th::Table* obj);
     void load_dictionaries(th::Table* obj, Dictionary& words, std::vector<Dictionary>& features);
     void load_dictionaries(th::Table* obj);
-    void load_networks(th::Table* obj, std::vector<nn::Module<MatFwd>*>& modules);
-    void load_networks(th::Table* obj);
+
+    void load_modules(th::Table* obj,
+                      std::vector<nn::Module<MatFwd>*>& modules,
+                      nn::ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& module_factory) const;
 
     th::Env _env;
-    nn::ModuleFactory<MatFwd, MatIn, MatEmb, ModelT> _module_factory;
-
-    std::vector<nn::Module<MatFwd>*> _encoder_modules;
-    std::vector<nn::Module<MatFwd>*> _decoder_modules;
+    th::Table* _root;
 
     Dictionary _src_dict;
     Dictionary _tgt_dict;

--- a/include/onmt/SubDict.h
+++ b/include/onmt/SubDict.h
@@ -17,7 +17,7 @@ namespace onmt
     SubDict(const std::string& map_file, const Dictionary& dict);
 
     /* given a sequence of words, extract sub-dictionary */
-    void extract(const std::vector<std::string>& words, std::set<size_t>& r);
+    void extract(const std::vector<std::string>& words, std::set<size_t>& r) const;
 
     bool empty() const
     {

--- a/include/onmt/Translator.h
+++ b/include/onmt/Translator.h
@@ -41,15 +41,18 @@ namespace onmt
                bool cuda,
                bool qlinear,
                bool profiling);
+    Translator(const Translator& other);
+
+    // Members shared accross translator instances.
+    std::shared_ptr<Model<MatFwd, MatIn, MatEmb, ModelT>> _model;
+    std::shared_ptr<const PhraseTable> _phrase_table;
+    std::shared_ptr<const SubDict> _subdict;
+
+    bool _cuda;
+    bool _profiling;
+    bool _qlinear;
 
     Profiler _profiler;
-    Model<MatFwd, MatIn, MatEmb, ModelT> _model;
-    const Dictionary& _src_dict;
-    const Dictionary& _tgt_dict;
-    const std::vector<Dictionary>& _src_feat_dicts;
-    const std::vector<Dictionary>& _tgt_feat_dicts;
-    PhraseTable _phrase_table;
-    SubDict _subdict;
     bool _replace_unk;
     size_t _max_sent_length;
     size_t _beam_size;
@@ -75,6 +78,9 @@ namespace onmt
            const std::vector<size_t>& subvocab);
 
   private:
+    void init_graph();
+
+    nn::ModuleFactory<MatFwd, MatIn, MatEmb, ModelT> _factory;
     nn::Module<MatFwd>* _encoder;
     nn::Module<MatFwd>* _encoder_bwd;
     nn::Module<MatFwd>* _decoder;

--- a/include/onmt/TranslatorFactory.h
+++ b/include/onmt/TranslatorFactory.h
@@ -19,6 +19,8 @@ namespace onmt
                                               bool cuda = false,
                                               bool qlinear = false,
                                               bool profiling = false);
+
+    static std::unique_ptr<ITranslator> clone(const std::unique_ptr<ITranslator>& translator);
   };
 
 }

--- a/src/SubDict.cc
+++ b/src/SubDict.cc
@@ -56,7 +56,7 @@ namespace onmt
     }
   }
 
-  void SubDict::extract(const std::vector<std::string>& words, std::set<size_t>& r)
+  void SubDict::extract(const std::vector<std::string>& words, std::set<size_t>& r) const
   {
     std::multimap<std::string, size_t>::const_iterator it;
 

--- a/src/TranslatorFactory.cc
+++ b/src/TranslatorFactory.cc
@@ -28,4 +28,12 @@ namespace onmt
     return std::unique_ptr<ITranslator>(t);
   }
 
+  std::unique_ptr<ITranslator>
+  TranslatorFactory::clone(const std::unique_ptr<ITranslator>& translator)
+  {
+    ITranslator* t = new DefaultTranslator<float>(
+      dynamic_cast<const DefaultTranslator<float>&>(*translator));
+    return std::unique_ptr<ITranslator>(t);
+  }
+
 }


### PR DESCRIPTION
This change unties the model loading and the graph creation to allow cloning a Translator instance while sharing static data like weights, dictionaries, and phrase tables.