### PR TITLE
Change translate functions back to single translation return, and add…

### DIFF
--- a/cli/translate.cc
+++ b/cli/translate.cc
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
                      auto batch = p_reader->read_next();
                      if (batch.empty())
                        break;
-                     auto res = p_trans->translate_batch(batch.get_data());
+                     auto res = p_trans->get_translations_batch(batch.get_data());
                      p_writer->write(BatchOutput(res, batch.get_id()));
                    }
                    return true;

--- a/include/onmt/ITranslator.h
+++ b/include/onmt/ITranslator.h
@@ -15,12 +15,19 @@ namespace onmt
     virtual ~ITranslator() = default;
 
     // Translate a raw text. If the tokenizer is not given, the input text is split on spaces.
-    virtual std::vector<std::string>
+    virtual std::string
     translate(const std::string& text);
-    virtual std::vector<std::string>
-    translate(const std::string& text, ITokenizer& tokenizer) = 0;
+    virtual std::string
+    translate(const std::string& text, ITokenizer& tokenizer);
 
-    // Translate pre-tokenized text.
+    // Multiple translations version of the previous methods.
+
+    virtual std::vector<std::string>
+    get_translations(const std::string& text);
+    virtual std::vector<std::string>
+    get_translations(const std::string& text, ITokenizer& tokenizer) = 0;
+
+    // Translate pre-tokenized text. (As with previous methods, this is also for multiple translations.)
     virtual TranslationResult
     translate(const std::vector<std::string>& tokens,
               const std::vector<std::vector<std::string> >& features) = 0;
@@ -28,11 +35,19 @@ namespace onmt
 
     // Batch version of the previous methods: translate several sequences at once.
 
-    virtual std::vector<std::vector<std::string> >
+    virtual std::vector<std::string>
     translate_batch(const std::vector<std::string>& texts);
-    virtual std::vector<std::vector<std::string> >
-    translate_batch(const std::vector<std::string>& texts, ITokenizer& tokenizer) = 0;
+    virtual std::vector<std::string>
+    translate_batch(const std::vector<std::string>& texts, ITokenizer& tokenizer);
 
+    // Multiple translations version of the previous methods.
+
+    virtual std::vector<std::vector<std::string> >
+    get_translations_batch(const std::vector<std::string>& texts);
+    virtual std::vector<std::vector<std::string> >
+    get_translations_batch(const std::vector<std::string>& texts, ITokenizer& tokenizer) = 0;
+
+    // Translate pre-tokenized text. (As with previous methods, this is also for multiple translations.)
     virtual TranslationResult
     translate_batch(const std::vector<std::vector<std::string> >& batch_tokens,
                     const std::vector<std::vector<std::vector<std::string> > >& batch_features) = 0;

--- a/include/onmt/TranslationResult.h
+++ b/include/onmt/TranslationResult.h
@@ -15,20 +15,20 @@ namespace onmt
                       const std::vector<std::vector<std::vector<std::vector<std::string> > > >& features,
                       const std::vector<std::vector<std::vector<std::vector<float> > > >& attention);
 
-    const std::vector<std::string>& get_words(size_t batch_index, size_t text_index) const;
-    const std::vector<std::vector<std::string> >& get_features(size_t batch_index, size_t text_index) const;
-    const std::vector<std::vector<float> >& get_attention(size_t batch_index, size_t text_index) const;
+    const std::vector<std::string>& get_words(size_t job_index = 0, size_t translation_index = 0) const;
+    const std::vector<std::vector<std::string> >& get_features(size_t job_index = 0, size_t translation_index = 0) const;
+    const std::vector<std::vector<float> >& get_attention(size_t job_index = 0, size_t translation_index = 0) const;
 
-    const std::vector<std::vector<std::string> >& get_words(size_t batch_index) const;
-    const std::vector<std::vector<std::vector<std::string> > >& get_features(size_t batch_index) const;
-    const std::vector<std::vector<std::vector<float> > >& get_attention(size_t batch_index) const;
-    size_t count(size_t batch_index) const;
+    const std::vector<std::vector<std::string> >& get_words_job(size_t job_index = 0) const;
+    const std::vector<std::vector<std::vector<std::string> > >& get_features_job(size_t job_index = 0) const;
+    const std::vector<std::vector<std::vector<float> > >& get_attention_job(size_t job_index = 0) const;
+    size_t count_job(size_t job_index = 0) const;
 
     const std::vector<std::vector<std::vector<std::string> > >& get_words_batch() const;
     const std::vector<std::vector<std::vector<std::vector<std::string> > > >& get_features_batch() const;
     const std::vector<std::vector<std::vector<std::vector<float> > > >& get_attention_batch() const;
 
-    size_t count_batch() const;
+    size_t count() const;
     bool has_features() const;
 
   private:

--- a/include/onmt/Translator.h
+++ b/include/onmt/Translator.h
@@ -20,8 +20,8 @@ namespace onmt
   public:
     friend class TranslatorFactory;
 
-    std::vector<std::string> translate(const std::string& text, ITokenizer& tokenizer) override;
-    std::vector<std::vector<std::string> > translate_batch(const std::vector<std::string>& texts, ITokenizer& tokenizer) override;
+    std::vector<std::string> get_translations(const std::string& text, ITokenizer& tokenizer) override;
+    std::vector<std::vector<std::string> > get_translations_batch(const std::vector<std::string>& texts, ITokenizer& tokenizer) override;
 
     TranslationResult
     translate(const std::vector<std::string>& tokens,

--- a/include/onmt/Translator.hxx
+++ b/include/onmt/Translator.hxx
@@ -200,7 +200,7 @@ namespace onmt
   }
 
   template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
-  std::vector<std::string> Translator<MatFwd, MatIn, MatEmb, ModelT>::translate(const std::string& text,
+  std::vector<std::string> Translator<MatFwd, MatIn, MatEmb, ModelT>::get_translations(const std::string& text,
                                                                    ITokenizer& tokenizer)
   {
     std::vector<std::string> src_tokens;
@@ -210,9 +210,9 @@ namespace onmt
 
     TranslationResult res = translate(src_tokens, src_features);
     std::vector<std::string> tgt_texts;
-    tgt_texts.reserve(res.count(0));
+    tgt_texts.reserve(res.count_job(0));
 
-    for (size_t i = 0; i < res.count(0); ++i)
+    for (size_t i = 0; i < res.count_job(0); ++i)
       tgt_texts.push_back(tokenizer.detokenize(res.get_words(0, i), res.get_features(0, i)));
 
     return tgt_texts;
@@ -254,7 +254,7 @@ namespace onmt
 
   template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
   std::vector<std::vector<std::string> >
-  Translator<MatFwd, MatIn, MatEmb, ModelT>::translate_batch(const std::vector<std::string>& texts,
+  Translator<MatFwd, MatIn, MatEmb, ModelT>::get_translations_batch(const std::vector<std::string>& texts,
                                                              ITokenizer& tokenizer)
   {
     std::vector<std::vector<std::string> > batch_tokens;
@@ -274,11 +274,11 @@ namespace onmt
     std::vector<std::vector<std::string> > tgt_texts;
     tgt_texts.reserve(texts.size());
 
-    for (size_t i = 0; i < res.count_batch(); ++i)
+    for (size_t i = 0; i < res.count(); ++i)
     {
       tgt_texts.emplace_back();
-      tgt_texts[i].reserve(res.count(i));
-      for (size_t j = 0; j < res.count(i); ++j)
+      tgt_texts[i].reserve(res.count_job(i));
+      for (size_t j = 0; j < res.count_job(i); ++j)
       {
         if (res.has_features())
           tgt_texts[i].push_back(tokenizer.detokenize(res.get_words(i, j), res.get_features(i, j)));

--- a/src/ITranslator.cc
+++ b/src/ITranslator.cc
@@ -5,14 +5,34 @@
 namespace onmt
 {
 
-  std::vector<std::string> ITranslator::translate(const std::string& text)
+  std::string ITranslator::translate(const std::string& text)
   {
     return translate(text, SpaceTokenizer::get_instance());
   }
 
-  std::vector<std::vector<std::string> > ITranslator::translate_batch(const std::vector<std::string>& texts)
+  std::string ITranslator::translate(const std::string& text, ITokenizer& tokenizer)
+  {
+    return get_translations(text, tokenizer).at(0);
+  }
+
+  std::vector<std::string> ITranslator::translate_batch(const std::vector<std::string>& texts)
   {
     return translate_batch(texts, SpaceTokenizer::get_instance());
+  }
+
+  std::vector<std::string> ITranslator::translate_batch(const std::vector<std::string>& texts, ITokenizer& tokenizer)
+  {
+    return get_translations_batch(texts, tokenizer).at(0);
+  }
+
+  std::vector<std::string> ITranslator::get_translations(const std::string& text)
+  {
+    return get_translations(text, SpaceTokenizer::get_instance());
+  }
+
+  std::vector<std::vector<std::string> > ITranslator::get_translations_batch(const std::vector<std::string>& texts)
+  {
+    return get_translations_batch(texts, SpaceTokenizer::get_instance());
   }
 
 }

--- a/src/TranslationResult.cc
+++ b/src/TranslationResult.cc
@@ -12,39 +12,39 @@ namespace onmt
   {
   }
 
-  const std::vector<std::string>& TranslationResult::get_words(size_t batch_index, size_t text_index) const
+  const std::vector<std::string>& TranslationResult::get_words(size_t job_index, size_t translation_index) const
   {
-    return _words[batch_index][text_index];
+    return _words[job_index][translation_index];
   }
 
-  const std::vector<std::vector<std::string> >& TranslationResult::get_features(size_t batch_index, size_t text_index) const
+  const std::vector<std::vector<std::string> >& TranslationResult::get_features(size_t job_index, size_t translation_index) const
   {
-    return _features[batch_index][text_index];
+    return _features[job_index][translation_index];
   }
 
-  const std::vector<std::vector<float> >& TranslationResult::get_attention(size_t batch_index, size_t text_index) const
+  const std::vector<std::vector<float> >& TranslationResult::get_attention(size_t job_index, size_t translation_index) const
   {
-    return _attention[batch_index][text_index];
+    return _attention[job_index][translation_index];
   }
 
-  const std::vector<std::vector<std::string> >& TranslationResult::get_words(size_t batch_index) const
+  const std::vector<std::vector<std::string> >& TranslationResult::get_words_job(size_t job_index) const
   {
-    return _words[batch_index];
+    return _words[job_index];
   }
 
-  const std::vector<std::vector<std::vector<std::string> > >& TranslationResult::get_features(size_t batch_index) const
+  const std::vector<std::vector<std::vector<std::string> > >& TranslationResult::get_features_job(size_t job_index) const
   {
-    return _features[batch_index];
+    return _features[job_index];
   }
 
-  const std::vector<std::vector<std::vector<float> > >& TranslationResult::get_attention(size_t batch_index) const
+  const std::vector<std::vector<std::vector<float> > >& TranslationResult::get_attention_job(size_t job_index) const
   {
-    return _attention[batch_index];
+    return _attention[job_index];
   }
 
-  size_t TranslationResult::count(size_t batch_index) const
+  size_t TranslationResult::count_job(size_t job_index) const
   {
-    return _words[batch_index].size();
+    return _words[job_index].size();
   }
 
   const std::vector<std::vector<std::vector<std::string> > >& TranslationResult::get_words_batch() const
@@ -62,7 +62,7 @@ namespace onmt
     return _attention;
   }
 
-  size_t TranslationResult::count_batch() const
+  size_t TranslationResult::count() const
   {
     return _words.size();
   }


### PR DESCRIPTION
… get_translations functions for getting multiple translations

Note that there is no optimisation done for a call to `translate` (single translation return) with `n_best` greater than 1 (optimisation would be to set `n_best` to 1).  Perhaps options such as `n_best` and `beam_size` should be moved from the `Translator` builder/constructor to parameters in the `get_translations` methods.