### PR TITLE
Fix for compile error: unknown type name 'int32_t'

### DIFF
--- a/lib/TH/THDiskFile.c
+++ b/lib/TH/THDiskFile.c
@@ -2,9 +2,7 @@
 #include "THDiskFile.h"
 #include "THFilePrivate.h"
 
-#ifdef _WIN64
 #include <stdint.h>
-#endif
 
 typedef struct THDiskFile__
 {


### PR DESCRIPTION
Issue #47