### PR TITLE
Respect threads parameter in cli when MKL is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ if (WITH_QLINEAR)
 endif()
 
 if (MKL_FOUND)
+  add_definitions(-DWITH_MKL)
   add_definitions(-DEIGEN_USE_MKL_ALL)
   list(APPEND INCLUDE_DIRECTORIES ${MKL_INCLUDE_DIR})
   list(APPEND LIBRARIES ${MKL_LIBRARIES})

--- a/src/Threads.cc
+++ b/src/Threads.cc
@@ -1,13 +1,19 @@
 #include "onmt/Threads.h"
 
 #include <Eigen/Core>
+#ifdef WITH_MKL
+#  include <mkl.h>
+#endif
 
 namespace onmt
 {
 
   void Threads::set(int number)
   {
-    return Eigen::setNbThreads(number);
+    Eigen::setNbThreads(number);
+#ifdef WITH_MKL
+    mkl_set_num_threads(number);
+#endif
   }
 
   int Threads::get()


### PR DESCRIPTION
This is a fix for the `threads `parameter which wasn't respected when Intel MKL was used.