### PR TITLE
Translation options flexibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SOURCES
   src/Profiler.cc
   src/ITranslator.cc
   src/TranslatorFactory.cc
+  src/TranslationOptions.cc
   src/TranslationResult.cc
   src/Threads.cc
   )

--- a/include/onmt/ITranslator.h
+++ b/include/onmt/ITranslator.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "onmt/ITokenizer.h"
+#include "onmt/TranslationOptions.h"
 #include "onmt/TranslationResult.h"
 
 namespace onmt
@@ -16,17 +17,20 @@ namespace onmt
 
     // Translate a raw text. If the tokenizer is not given, the input text is split on spaces.
     virtual std::string
-    translate(const std::string& text);
+    translate(const std::string& text,
+              const TranslationOptions& options = TranslationOptions());
     virtual std::string
     translate(const std::string& text,
               float& score,
               size_t& count_tgt_words,
               size_t& count_tgt_unk_words,
               size_t& count_src_words,
-              size_t& count_src_unk_words);
+              size_t& count_src_unk_words,
+              const TranslationOptions& options = TranslationOptions());
     virtual std::string
     translate(const std::string& text,
-              ITokenizer& tokenizer);
+              ITokenizer& tokenizer,
+              const TranslationOptions& options = TranslationOptions());
     virtual std::string
     translate(const std::string& text,
               ITokenizer& tokenizer,
@@ -34,22 +38,26 @@ namespace onmt
               size_t& count_tgt_words,
               size_t& count_tgt_unk_words,
               size_t& count_src_words,
-              size_t& count_src_unk_words);
+              size_t& count_src_unk_words,
+              const TranslationOptions& options = TranslationOptions());
 
     // Multiple translations version of the previous methods.
 
     virtual std::vector<std::string>
-    get_translations(const std::string& text);
+    get_translations(const std::string& text,
+                     const TranslationOptions& options = TranslationOptions());
     virtual std::vector<std::string>
     get_translations(const std::string& text,
                      std::vector<float>& scores,
                      std::vector<size_t>& count_tgt_words,
                      std::vector<size_t>& count_tgt_unk_words,
                      size_t& count_src_words,
-                     size_t& count_src_unk_words);
+                     size_t& count_src_unk_words,
+                     const TranslationOptions& options = TranslationOptions());
     virtual std::vector<std::string>
     get_translations(const std::string& text,
-                     ITokenizer& tokenizer);
+                     ITokenizer& tokenizer,
+                     const TranslationOptions& options = TranslationOptions());
     virtual std::vector<std::string>
     get_translations(const std::string& text,
                      ITokenizer& tokenizer,
@@ -57,32 +65,37 @@ namespace onmt
                      std::vector<size_t>& count_tgt_words,
                      std::vector<size_t>& count_tgt_unk_words,
                      size_t& count_src_words,
-                     size_t& count_src_unk_words) = 0;
+                     size_t& count_src_unk_words,
+                     const TranslationOptions& options = TranslationOptions()) = 0;
 
     // Translate pre-tokenized text. (As with previous methods, this is also for multiple translations.)
     virtual TranslationResult
     translate(const std::vector<std::string>& tokens,
-              const std::vector<std::vector<std::string> >& features);
+              const std::vector<std::vector<std::string> >& features,
+              const TranslationOptions& options = TranslationOptions());
     virtual TranslationResult
     translate(const std::vector<std::string>& tokens,
               const std::vector<std::vector<std::string> >& features,
-              size_t& count_src_unk_words) = 0;
-
+              size_t& count_src_unk_words,
+              const TranslationOptions& options = TranslationOptions()) = 0;
 
     // Batch version of the previous methods: translate several sequences at once.
 
     virtual std::vector<std::string>
-    translate_batch(const std::vector<std::string>& texts);
+    translate_batch(const std::vector<std::string>& texts,
+                    const TranslationOptions& options = TranslationOptions());
     virtual std::vector<std::string>
     translate_batch(const std::vector<std::string>& texts,
                     std::vector<float>& scores,
                     std::vector<size_t>& count_tgt_words,
                     std::vector<size_t>& count_tgt_unk_words,
                     std::vector<size_t>& count_src_words,
-                    std::vector<size_t>& count_src_unk_words);
+                    std::vector<size_t>& count_src_unk_words,
+                    const TranslationOptions& options = TranslationOptions());
     virtual std::vector<std::string>
     translate_batch(const std::vector<std::string>& texts,
-                    ITokenizer& tokenizer);
+                    ITokenizer& tokenizer,
+                    const TranslationOptions& options = TranslationOptions());
     virtual std::vector<std::string>
     translate_batch(const std::vector<std::string>& texts,
                     ITokenizer& tokenizer,
@@ -90,22 +103,26 @@ namespace onmt
                     std::vector<size_t>& count_tgt_words,
                     std::vector<size_t>& count_tgt_unk_words,
                     std::vector<size_t>& count_src_words,
-                    std::vector<size_t>& count_src_unk_words);
+                    std::vector<size_t>& count_src_unk_words,
+                    const TranslationOptions& options = TranslationOptions());
 
     // Multiple translations version of the previous methods.
 
     virtual std::vector<std::vector<std::string> >
-    get_translations_batch(const std::vector<std::string>& texts);
+    get_translations_batch(const std::vector<std::string>& texts,
+                           const TranslationOptions& options = TranslationOptions());
     virtual std::vector<std::vector<std::string> >
     get_translations_batch(const std::vector<std::string>& texts,
                            std::vector<std::vector<float> >& scores,
                            std::vector<std::vector<size_t> >& count_tgt_words,
                            std::vector<std::vector<size_t> >& count_tgt_unk_words,
                            std::vector<size_t>& count_src_words,
-                           std::vector<size_t>& count_src_unk_words);
+                           std::vector<size_t>& count_src_unk_words,
+                           const TranslationOptions& options = TranslationOptions());
     virtual std::vector<std::vector<std::string> >
     get_translations_batch(const std::vector<std::string>& texts,
-                           ITokenizer& tokenizer);
+                           ITokenizer& tokenizer,
+                           const TranslationOptions& options = TranslationOptions());
     virtual std::vector<std::vector<std::string> >
     get_translations_batch(const std::vector<std::string>& texts,
                            ITokenizer& tokenizer,
@@ -113,16 +130,19 @@ namespace onmt
                            std::vector<std::vector<size_t> >& count_tgt_words,
                            std::vector<std::vector<size_t> >& count_tgt_unk_words,
                            std::vector<size_t>& count_src_words,
-                           std::vector<size_t>& count_src_unk_words) = 0;
+                           std::vector<size_t>& count_src_unk_words,
+                           const TranslationOptions& options = TranslationOptions()) = 0;
 
     // Translate pre-tokenized text. (As with previous methods, this is also for multiple translations.)
     virtual TranslationResult
     translate_batch(const std::vector<std::vector<std::string> >& batch_tokens,
-                    const std::vector<std::vector<std::vector<std::string> > >& batch_features);
+                    const std::vector<std::vector<std::vector<std::string> > >& batch_features,
+                    const TranslationOptions& options = TranslationOptions());
     virtual TranslationResult
     translate_batch(const std::vector<std::vector<std::string> >& batch_tokens,
                     const std::vector<std::vector<std::vector<std::string> > >& batch_features,
-                    std::vector<size_t>& batch_count_src_unk_words) = 0;
+                    std::vector<size_t>& batch_count_src_unk_words,
+                    const TranslationOptions& options = TranslationOptions()) = 0;
   };
 
 }

--- a/include/onmt/TranslationOptions.h
+++ b/include/onmt/TranslationOptions.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "onmt/onmt_export.h"
+
+namespace onmt
+{
+
+  class ONMT_EXPORT TranslationOptions
+  {
+  public:
+    TranslationOptions(size_t max_sent_length = 250,
+                       size_t beam_size = 5,
+                       size_t n_best = 1,
+                       bool replace_unk = true,
+                       bool replace_unk_tagged = false);
+
+    size_t max_sent_length() const;
+    size_t& max_sent_length();
+    size_t beam_size() const;
+    size_t& beam_size();
+    size_t n_best() const;
+    size_t& n_best();
+    bool replace_unk() const;
+    bool& replace_unk();
+    bool replace_unk_tagged() const;
+    bool& replace_unk_tagged();
+
+  private:
+    size_t _max_sent_length;
+    size_t _beam_size;
+    size_t _n_best;
+    bool _replace_unk;
+    bool _replace_unk_tagged;
+  };
+
+}

--- a/include/onmt/Translator.h
+++ b/include/onmt/Translator.h
@@ -27,7 +27,8 @@ namespace onmt
                      std::vector<size_t>& count_tgt_words,
                      std::vector<size_t>& count_tgt_unk_words,
                      size_t& count_src_words,
-                     size_t& count_src_unk_words) override;
+                     size_t& count_src_unk_words,
+                     const TranslationOptions& options = TranslationOptions()) override;
 
     std::vector<std::vector<std::string> >
     get_translations_batch(const std::vector<std::string>& texts,
@@ -36,27 +37,25 @@ namespace onmt
                            std::vector<std::vector<size_t> >& count_tgt_words,
                            std::vector<std::vector<size_t> >& count_tgt_unk_words,
                            std::vector<size_t>& count_src_words,
-                           std::vector<size_t>& count_src_unk_words) override;
+                           std::vector<size_t>& count_src_unk_words,
+                           const TranslationOptions& options = TranslationOptions()) override;
 
     TranslationResult
     translate(const std::vector<std::string>& tokens,
               const std::vector<std::vector<std::string> >& features,
-              size_t& count_src_unk_words) override;
+              size_t& count_src_unk_words,
+              const TranslationOptions& options = TranslationOptions()) override;
 
     TranslationResult
     translate_batch(const std::vector<std::vector<std::string> >& batch_tokens,
                     const std::vector<std::vector<std::vector<std::string> > >& batch_features,
-                    std::vector<size_t>& batch_count_src_unk_words) override;
+                    std::vector<size_t>& batch_count_src_unk_words,
+                    const TranslationOptions& options = TranslationOptions()) override;
 
   protected:
     Translator(const std::string& model,
                const std::string& phrase_table,
                const std::string& vocab_mapping,
-               bool replace_unk,
-               bool replace_unk_tagged,
-               size_t max_sent_length,
-               size_t beam_size,
-               size_t n_best,
                bool cuda,
                bool qlinear,
                bool profiling);
@@ -66,19 +65,13 @@ namespace onmt
     bool _profiling;
     Profiler _profiler;
 
-    // Members shared accross translator instances.
+    // Members shared across translator instances.
     std::shared_ptr<Model<MatFwd, MatIn, MatEmb, ModelT>> _model;
     std::shared_ptr<const PhraseTable> _phrase_table;
     std::shared_ptr<const SubDict> _subdict;
 
     bool _cuda;
     bool _qlinear;
-
-    bool _replace_unk;
-    bool _replace_unk_tagged;
-    size_t _max_sent_length;
-    size_t _beam_size;
-    size_t _n_best;
 
     std::vector<MatFwd>
     get_encoder_input(size_t t,
@@ -98,7 +91,8 @@ namespace onmt
            size_t source_l,
            const std::vector<MatFwd>& rnn_state_enc,
            const MatFwd& context,
-           const std::vector<size_t>& subvocab);
+           const std::vector<size_t>& subvocab,
+           const TranslationOptions& options);
 
   private:
     void init_graph();

--- a/include/onmt/TranslatorFactory.h
+++ b/include/onmt/TranslatorFactory.h
@@ -14,11 +14,6 @@ namespace onmt
     static std::unique_ptr<ITranslator> build(const std::string& model,
                                               const std::string& phrase_table = "",
                                               const std::string& vocab_mapping = "",
-                                              bool replace_unk = true,
-                                              bool replace_unk_tagged = false,
-                                              size_t max_sent_length = 250,
-                                              size_t beam_size = 5,
-                                              size_t n_best = 1,
                                               bool cuda = false,
                                               bool qlinear = false,
                                               bool profiling = false);

--- a/src/ITranslator.cc
+++ b/src/ITranslator.cc
@@ -6,9 +6,10 @@ namespace onmt
 {
 
   std::string
-  ITranslator::translate(const std::string& text)
+  ITranslator::translate(const std::string& text,
+                         const TranslationOptions& options)
   {
-    return translate(text, SpaceTokenizer::get_instance());
+    return translate(text, SpaceTokenizer::get_instance(), options);
   }
 
   std::string
@@ -17,18 +18,20 @@ namespace onmt
                          size_t& count_tgt_words,
                          size_t& count_tgt_unk_words,
                          size_t& count_src_words,
-                         size_t& count_src_unk_words)
+                         size_t& count_src_unk_words,
+                         const TranslationOptions& options)
   {
-    return translate(text, SpaceTokenizer::get_instance(), score, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words);
+    return translate(text, SpaceTokenizer::get_instance(), score, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words, options);
   }
 
   std::string
   ITranslator::translate(const std::string& text,
-                         ITokenizer& tokenizer)
+                         ITokenizer& tokenizer,
+                         const TranslationOptions& options)
   {
     float score;
     size_t count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words;
-    return translate(text, tokenizer, score, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words);
+    return translate(text, tokenizer, score, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words, options);
   }
 
   std::string
@@ -38,11 +41,12 @@ namespace onmt
                          size_t& count_tgt_words,
                          size_t& count_tgt_unk_words,
                          size_t& count_src_words,
-                         size_t& count_src_unk_words)
+                         size_t& count_src_unk_words,
+                         const TranslationOptions& options)
   {
     std::vector<float> best_scores;
     std::vector<size_t> best_count_tgt_words, best_count_tgt_unk_words;
-    auto res = get_translations(text, tokenizer, best_scores, best_count_tgt_words, best_count_tgt_unk_words, count_src_words, count_src_unk_words);
+    auto res = get_translations(text, tokenizer, best_scores, best_count_tgt_words, best_count_tgt_unk_words, count_src_words, count_src_unk_words, options);
     score = best_scores.at(0);
     count_tgt_words = best_count_tgt_words.at(0);
     count_tgt_unk_words = best_count_tgt_unk_words.at(0);
@@ -50,9 +54,10 @@ namespace onmt
   }
 
   std::vector<std::string>
-  ITranslator::get_translations(const std::string& text)
+  ITranslator::get_translations(const std::string& text,
+                                const TranslationOptions& options)
   {
-    return get_translations(text, SpaceTokenizer::get_instance());
+    return get_translations(text, SpaceTokenizer::get_instance(), options);
   }
 
   std::vector<std::string>
@@ -61,33 +66,37 @@ namespace onmt
                                 std::vector<size_t>& count_tgt_words,
                                 std::vector<size_t>& count_tgt_unk_words,
                                 size_t& count_src_words,
-                                size_t& count_src_unk_words)
+                                size_t& count_src_unk_words,
+                                const TranslationOptions& options)
   {
-    return get_translations(text, SpaceTokenizer::get_instance(), scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words);
+    return get_translations(text, SpaceTokenizer::get_instance(), scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words, options);
   }
 
   std::vector<std::string>
   ITranslator::get_translations(const std::string& text,
-                                ITokenizer& tokenizer)
+                                ITokenizer& tokenizer,
+                                const TranslationOptions& options)
   {
     std::vector<float> scores;
     std::vector<size_t> count_tgt_words, count_tgt_unk_words;
     size_t count_src_words, count_src_unk_words;
-    return get_translations(text, tokenizer, scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words);
+    return get_translations(text, tokenizer, scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words, options);
   }
 
   TranslationResult
   ITranslator::translate(const std::vector<std::string>& tokens,
-                         const std::vector<std::vector<std::string> >& features)
+                         const std::vector<std::vector<std::string> >& features,
+                         const TranslationOptions& options)
   {
     size_t count_src_unk_words;
-    return translate(tokens, features, count_src_unk_words);
+    return translate(tokens, features, count_src_unk_words, options);
   }
 
   std::vector<std::string>
-  ITranslator::translate_batch(const std::vector<std::string>& texts)
+  ITranslator::translate_batch(const std::vector<std::string>& texts,
+                               const TranslationOptions& options)
   {
-    return translate_batch(texts, SpaceTokenizer::get_instance());
+    return translate_batch(texts, SpaceTokenizer::get_instance(), options);
   }
 
   std::vector<std::string>
@@ -96,19 +105,21 @@ namespace onmt
                                std::vector<size_t>& count_tgt_words,
                                std::vector<size_t>& count_tgt_unk_words,
                                std::vector<size_t>& count_src_words,
-                               std::vector<size_t>& count_src_unk_words)
+                               std::vector<size_t>& count_src_unk_words,
+                               const TranslationOptions& options)
   {
-    return translate_batch(texts, SpaceTokenizer::get_instance(), scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words);
+    return translate_batch(texts, SpaceTokenizer::get_instance(), scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words, options);
   }
 
   std::vector<std::string>
   ITranslator::translate_batch(const std::vector<std::string>& texts,
-                               ITokenizer& tokenizer)
+                               ITokenizer& tokenizer,
+                               const TranslationOptions& options)
   {
     std::vector<float> scores;
     std::vector<size_t> count_tgt_words, count_tgt_unk_words;
     std::vector<size_t> count_src_words, count_src_unk_words;
-    return translate_batch(texts, tokenizer, scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words);
+    return translate_batch(texts, tokenizer, scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words, options);
   }
 
   std::vector<std::string>
@@ -118,7 +129,8 @@ namespace onmt
                                std::vector<size_t>& count_tgt_words,
                                std::vector<size_t>& count_tgt_unk_words,
                                std::vector<size_t>& count_src_words,
-                               std::vector<size_t>& count_src_unk_words)
+                               std::vector<size_t>& count_src_unk_words,
+                               const TranslationOptions& options)
   {
     std::vector<std::string> translations;
     scores.clear();
@@ -126,7 +138,7 @@ namespace onmt
     count_tgt_unk_words.clear();
     std::vector<std::vector<float> > batch_scores;
     std::vector<std::vector<size_t> > batch_count_tgt_words, batch_count_tgt_unk_words;
-    auto res = get_translations_batch(texts, tokenizer, batch_scores, batch_count_tgt_words, batch_count_tgt_unk_words, count_src_words, count_src_unk_words);
+    auto res = get_translations_batch(texts, tokenizer, batch_scores, batch_count_tgt_words, batch_count_tgt_unk_words, count_src_words, count_src_unk_words, options);
     for (size_t i = 0; i < res.size(); ++i)
     {
       translations.push_back(std::move(res[i].at(0)));
@@ -139,9 +151,10 @@ namespace onmt
   }
 
   std::vector<std::vector<std::string> >
-  ITranslator::get_translations_batch(const std::vector<std::string>& texts)
+  ITranslator::get_translations_batch(const std::vector<std::string>& texts,
+                                      const TranslationOptions& options)
   {
-    return get_translations_batch(texts, SpaceTokenizer::get_instance());
+    return get_translations_batch(texts, SpaceTokenizer::get_instance(), options);
   }
 
   std::vector<std::vector<std::string> >
@@ -150,27 +163,30 @@ namespace onmt
                                       std::vector<std::vector<size_t> >& count_tgt_words,
                                       std::vector<std::vector<size_t> >& count_tgt_unk_words,
                                       std::vector<size_t>& count_src_words,
-                                      std::vector<size_t>& count_src_unk_words)
+                                      std::vector<size_t>& count_src_unk_words,
+                                      const TranslationOptions& options)
   {
-    return get_translations_batch(texts, SpaceTokenizer::get_instance(), scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words);
+    return get_translations_batch(texts, SpaceTokenizer::get_instance(), scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words, options);
   }
 
   std::vector<std::vector<std::string> >
   ITranslator::get_translations_batch(const std::vector<std::string>& texts,
-                                      ITokenizer& tokenizer)
+                                      ITokenizer& tokenizer,
+                                      const TranslationOptions& options)
   {
     std::vector<std::vector<float> > scores;
     std::vector<std::vector<size_t> > count_tgt_words, count_tgt_unk_words;
     std::vector<size_t> count_src_words, count_src_unk_words;
-    return get_translations_batch(texts, tokenizer, scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words);
+    return get_translations_batch(texts, tokenizer, scores, count_tgt_words, count_tgt_unk_words, count_src_words, count_src_unk_words, options);
   }
 
   TranslationResult
   ITranslator::translate_batch(const std::vector<std::vector<std::string> >& batch_tokens,
-                               const std::vector<std::vector<std::vector<std::string> > >& batch_features)
+                               const std::vector<std::vector<std::vector<std::string> > >& batch_features,
+                               const TranslationOptions& options)
   {
     std::vector<size_t> batch_count_src_unk_words;
-    return translate_batch(batch_tokens, batch_features, batch_count_src_unk_words);
+    return translate_batch(batch_tokens, batch_features, batch_count_src_unk_words, options);
   }
 
 }

--- a/src/TranslationOptions.cc
+++ b/src/TranslationOptions.cc
@@ -1,0 +1,69 @@
+#include "onmt/TranslationOptions.h"
+
+namespace onmt
+{
+
+  TranslationOptions::TranslationOptions(size_t max_sent_length,
+                                         size_t beam_size,
+                                         size_t n_best,
+                                         bool replace_unk,
+                                         bool replace_unk_tagged)
+    : _max_sent_length(max_sent_length)
+    , _beam_size(beam_size)
+    , _n_best(n_best)
+    , _replace_unk(replace_unk)
+    , _replace_unk_tagged(replace_unk_tagged)
+  {
+  }
+
+  size_t TranslationOptions::max_sent_length() const
+  {
+    return _max_sent_length;
+  }
+
+  size_t& TranslationOptions::max_sent_length()
+  {
+    return _max_sent_length;
+  }
+
+  size_t TranslationOptions::beam_size() const
+  {
+    return _beam_size;
+  }
+
+  size_t& TranslationOptions::beam_size()
+  {
+    return _beam_size;
+  }
+
+  size_t TranslationOptions::n_best() const
+  {
+    return _n_best;
+  }
+
+  size_t& TranslationOptions::n_best()
+  {
+    return _n_best;
+  }
+
+  bool TranslationOptions::replace_unk() const
+  {
+    return _replace_unk;
+  }
+
+  bool& TranslationOptions::replace_unk()
+  {
+    return _replace_unk;
+  }
+
+  bool TranslationOptions::replace_unk_tagged() const
+  {
+    return _replace_unk_tagged;
+  }
+
+  bool& TranslationOptions::replace_unk_tagged()
+  {
+    return _replace_unk_tagged;
+  }
+
+}

--- a/src/TranslatorFactory.cc
+++ b/src/TranslatorFactory.cc
@@ -6,11 +6,6 @@ namespace onmt
   std::unique_ptr<ITranslator> TranslatorFactory::build(const std::string& model,
                                                         const std::string& phrase_table,
                                                         const std::string& vocab_mapping,
-                                                        bool replace_unk,
-                                                        bool replace_unk_tagged,
-                                                        size_t max_sent_length,
-                                                        size_t beam_size,
-                                                        size_t n_best,
                                                         bool cuda,
                                                         bool qlinear,
                                                         bool profiling)
@@ -20,11 +15,6 @@ namespace onmt
     t = new DefaultTranslator<float>(model,
                                      phrase_table,
                                      vocab_mapping,
-                                     replace_unk,
-                                     replace_unk_tagged,
-                                     max_sent_length,
-                                     beam_size,
-                                     n_best,
                                      cuda,
                                      qlinear,
                                      profiling);


### PR DESCRIPTION
What do you think of these changes that move options that are specific to translating and not needed for "building" a translator (these options being `max_sent_length`, `beam_size`, `n_best`, `replace_unk`, `replace_unk_tagged`) from the `Translator` constructor to the `translate` function for greater flexibility? Otherwise it's necessary to build a new `Translator` each time one wants to change these options.