### PR TITLE
add missing include

### DIFF
--- a/include/onmt/cuda/Utils.h
+++ b/include/onmt/cuda/Utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <stdexcept>
 
 #include <cuda_runtime.h>


### PR DESCRIPTION
This adds a missing include (for `std::string/std::to_string`); Windows builds with Cuda fail without it.