### PR TITLE
fix for mismatched runtime library with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 3.1.0)
+
+# Set policy for setting the MSVC runtime library for static MSVC builds
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 project(onmt)
 
 option(LIB_ONLY "Do not compile clients" OFF)
@@ -36,7 +42,13 @@ if(ANDROID)
 endif()
 
 if(MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Wall")
+  if(NOT BUILD_SHARED_LIBS)
+    if(CMAKE_VERSION VERSION_LESS "3.15.0")
+      message(FATAL_ERROR "Use CMake 3.15 or later when setting BUILD_SHARED_LIBS to OFF")
+    endif()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
@@ -148,6 +160,13 @@ endif()
 
 if (CUDA_FOUND)
   add_definitions(-DWITH_CUDA)
+  if(MSVC)
+    if(BUILD_SHARED_LIBS)
+      set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler=/MD$<$<CONFIG:Debug>:d>")
+    else()
+      set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler=/MT$<$<CONFIG:Debug>:d>")
+    endif()
+  endif()
   cuda_include_directories(${INCLUDE_DIRECTORIES})
   cuda_add_library(${PROJECT_NAME}
     ${SOURCES}


### PR DESCRIPTION
This fixes the following build error with MSVC when building static libs (`BUILD_SHARED_LIBS=off`) as well as when building Debug DLLs with CUDA enabled.
`error LNK2038: mismatch detected for 'RuntimeLibrary'`
Requires cmake 3.15 (only for the case: MSVC + static).
This PR also decreases the warning level for MSVC builds.