### PR TITLE
improve translator clone, eliminate redundant memory usage

### DIFF
--- a/include/onmt/Model.h
+++ b/include/onmt/Model.h
@@ -16,8 +16,8 @@ namespace onmt
     Model(const std::string& filename);
 
     void create_graph(nn::ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory,
-                      std::vector<nn::Module<MatFwd>*>& encoder,
-                      std::vector<nn::Module<MatFwd>*>& decoder);
+                      std::vector<size_t>& encoder,
+                      std::vector<size_t>& decoder);
 
     const Dictionary& get_src_dict() const;
     const Dictionary& get_tgt_dict() const;
@@ -36,7 +36,7 @@ namespace onmt
     void load_dictionaries(th::Table* obj);
 
     void load_modules(th::Table* obj,
-                      std::vector<nn::Module<MatFwd>*>& modules,
+                      std::vector<size_t>& modules,
                       nn::ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& module_factory) const;
 
     th::Env _env;
@@ -49,7 +49,7 @@ namespace onmt
 
     std::unordered_map<std::string, double> _options_value;
     std::unordered_map<std::string, std::string> _options_str;
-    std::string _empty_str = "";
+    const std::string _empty_str;
   };
 
 }

--- a/include/onmt/Translator.h
+++ b/include/onmt/Translator.h
@@ -69,6 +69,8 @@ namespace onmt
     std::shared_ptr<Model<MatFwd, MatIn, MatEmb, ModelT>> _model;
     std::shared_ptr<const PhraseTable> _phrase_table;
     std::shared_ptr<const SubDict> _subdict;
+    std::shared_ptr<std::vector<size_t>> _encoder_mod_ids;
+    std::shared_ptr<std::vector<size_t>> _decoder_mod_ids;
 
     bool _cuda;
     bool _qlinear;
@@ -98,10 +100,10 @@ namespace onmt
     void init_graph();
 
     nn::ModuleFactory<MatFwd, MatIn, MatEmb, ModelT> _factory;
-    nn::Module<MatFwd>* _encoder;
-    nn::Module<MatFwd>* _encoder_bwd;
-    nn::Module<MatFwd>* _decoder;
-    nn::Module<MatFwd>* _generator;
+    nn::Module<MatFwd, MatIn, MatEmb, ModelT>* _encoder;
+    nn::Module<MatFwd, MatIn, MatEmb, ModelT>* _encoder_bwd;
+    nn::Module<MatFwd, MatIn, MatEmb, ModelT>* _decoder;
+    nn::Module<MatFwd, MatIn, MatEmb, ModelT>* _generator;
   };
 
 

--- a/include/onmt/cuda/Utils.h
+++ b/include/onmt/cuda/Utils.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <stdexcept>
+#include <cstdlib>
 
 #include <cuda_runtime.h>
 #include <cublas_v2.h>
@@ -74,7 +75,7 @@ namespace onmt
     T* to_host(const T* device, T* host, int rows, int cols)
     {
       if (!host)
-        host = (T*) malloc(rows * cols * sizeof (T));
+        host = (T*) std::malloc(rows * cols * sizeof (T));
 
       CUBLAS_CHECK(cublasGetMatrix(rows, cols, sizeof (T), device, rows, host, rows));
 

--- a/include/onmt/nn/CAddTable.h
+++ b/include/onmt/nn/CAddTable.h
@@ -7,13 +7,23 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class CAddTable: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class CAddTable: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       CAddTable()
-        : Module<MatFwd>("nn.CAddTable")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.CAddTable")
       {
+      }
+
+      CAddTable(const CAddTable& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new CAddTable(*this);
       }
 
       void forward_impl(const std::vector<MatFwd>& inputs) override

--- a/include/onmt/nn/CMulTable.h
+++ b/include/onmt/nn/CMulTable.h
@@ -7,13 +7,23 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class CMulTable: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class CMulTable: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       CMulTable()
-        : Module<MatFwd>("nn.CMulTable")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.CMulTable")
       {
+      }
+
+      CMulTable(const CMulTable& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new CMulTable(*this);
       }
 
       void forward_impl(const std::vector<MatFwd>& inputs) override

--- a/include/onmt/nn/ConcatTable.h
+++ b/include/onmt/nn/ConcatTable.h
@@ -16,12 +16,23 @@ namespace onmt
       {
       }
 
+      ConcatTable(const ConcatTable& other,
+                  const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory)
+        : Container<MatFwd, MatIn, MatEmb, ModelT>(other, factory)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>* factory) const override
+      {
+        return new ConcatTable(*this, *factory);
+      }
+
       void forward_impl(const std::vector<MatFwd>& inputs) override
       {
-        this->_outputs.resize(this->_sequence.size());
+        this->_outputs.resize(this->_sequence->size());
 
-        for (size_t i = 0; i < this->_sequence.size(); ++i)
-          this->_outputs[i] = this->_sequence[i]->forward(inputs)[0];
+        for (size_t i = 0; i < this->_sequence->size(); ++i)
+          this->_outputs[i] = this->_factory.get_module((*(this->_sequence))[i])->forward(inputs)[0];
       }
     };
 

--- a/include/onmt/nn/Container.h
+++ b/include/onmt/nn/Container.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include "onmt/nn/ModuleFactory.h"
 #include "onmt/th/Utils.h"
 #include "onmt/th/Obj.h"
@@ -10,38 +11,49 @@ namespace onmt
   {
 
     template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
-    class Container: public Module<MatFwd>
+    class Container: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       Container(const std::string& name,
                 th::Table* data,
                 ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory)
-        : Module<MatFwd>(name, false)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(name, false)
+        , _factory(factory)
+        , _sequence(new std::vector<size_t>())
       {
         th::Table* modules = th::get_field<th::Table*>(data, "modules");
-        _sequence.reserve(modules->get_array().size());
+        _sequence->reserve(modules->get_array().size());
 
         for (auto module_obj: modules->get_array())
         {
           th::Class* module = dynamic_cast<th::Class*>(module_obj);
-          _sequence.push_back(factory.build(module));
+          _sequence->push_back(factory.build(module));
         }
       }
 
+      Container(const Container& other,
+                const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _factory(factory)
+        , _sequence(other._sequence)
+      {
+      }
+
       /* apply recursively a generic function to each node of the graph */
-      void* apply(void* (*func)(Module<MatFwd>*, void*), void* data)
+      void* apply(void* (*func)(Module<MatFwd, MatIn, MatEmb, ModelT>*, void*), void* data)
       {
         func(this, data);
 
-        for (auto child: _sequence)
-          child->apply(func, data);
+        for (auto child: *_sequence)
+          _factory.get_module(child)->apply(func, data);
         return 0;
       }
 
       virtual void forward_impl(const std::vector<MatFwd>& inputs) = 0;
 
     protected:
-      std::vector<Module<MatFwd>*> _sequence;
+      const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& _factory;
+      std::shared_ptr<std::vector<size_t>> _sequence;
     };
 
   }

--- a/include/onmt/nn/Graph.h
+++ b/include/onmt/nn/Graph.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <limits>
+#include <unordered_map>
+
 #include "onmt/nn/ModuleFactory.h"
 #include "onmt/nn/Node.h"
 #include "onmt/th/Obj.h"
@@ -11,42 +14,61 @@ namespace onmt
   {
 
     template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
-    class Graph: public Module<MatFwd>
+    class Graph: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       Graph(th::Class* module,
             const std::string& name,
             ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory)
-        : Module<MatFwd>(name, false)
-        , _root(build_graph(dynamic_cast<th::Table*>(
-                              dynamic_cast<th::Table*>(module->get_data())
-                              ->get_object().at("forwardnodes"))
-                            ->get_array()[0],
-                            factory))
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(name, false)
+        , _root_id(build_graph(dynamic_cast<th::Table*>(
+                                 dynamic_cast<th::Table*>(module->get_data())
+                                 ->get_object().at("forwardnodes"))
+                               ->get_array()[0],
+                               factory))
+        , _root(&(_node_map.find(_root_id)->second))
       {
+      }
+
+      Graph(const Graph& other,
+            const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _root_id(other._root_id)
+      {
+        for (const auto& it: other._node_map)
+        {
+          _node_map.emplace(std::piecewise_construct,
+            std::forward_as_tuple(it.first), std::forward_as_tuple(it.second, factory, _node_map));
+        }
+        _root = &(_node_map.find(_root_id)->second);
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>* factory) const override
+      {
+        return new Graph(*this, *factory);
       }
 
       void forward_impl(const std::vector<MatFwd>& inputs) override
       {
-        _root.forward(inputs, this->_outputs, nullptr);
+        _root->forward(inputs, this->_outputs, nullptr);
       }
 
-      Module<MatFwd>* find(const std::string& custom_name) override
+      Module<MatFwd, MatIn, MatEmb, ModelT>* find(const std::string& custom_name) override
       {
         if (this->_custom_name == custom_name)
           return this;
 
-        return _root.find(custom_name);
+        return _root->find(custom_name);
       }
 
-      void* apply(void* (*func)(Module<MatFwd>*, void*), void* data) override
+      void* apply(void* (*func)(Module<MatFwd, MatIn, MatEmb, ModelT>*, void*), void* data) override
       {
         for(auto &it: _node_map)
           it.second.set_unvisited();
 
         func(this, data);
 
-        _root.apply(func, data);
+        _root->apply(func, data);
         return nullptr;
       }
 
@@ -58,15 +80,16 @@ namespace onmt
 
         std::ofstream out(file.c_str());
         out << "digraph " << name << " {" << std::endl;
-        _root.to_dot(out);
+        _root->to_dot(out);
         out << "}" << std::endl;
       }
 
     private:
-      std::map<size_t, Node<MatFwd> > _node_map;
-      Node<MatFwd>& _root;
+      std::unordered_map<size_t, Node<MatFwd, MatIn, MatEmb, ModelT>> _node_map;
+      size_t _root_id;
+      Node<MatFwd, MatIn, MatEmb, ModelT>* _root;
 
-      Node<MatFwd>& build_graph(th::Obj* root, ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory)
+      size_t build_graph(th::Obj* root, ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory)
       {
         th::Class* root_class = dynamic_cast<th::Class*>(root);
         th::Table* root_fields = dynamic_cast<th::Table*>(root_class->get_data());
@@ -74,24 +97,25 @@ namespace onmt
 
         size_t id = static_cast<size_t>(root_id->get_value());
 
-        auto placeholder = _node_map.emplace(id, id);
-        Node<MatFwd>& root_node = placeholder.first->second;
+        auto placeholder = _node_map.emplace(std::piecewise_construct,
+          std::forward_as_tuple(id), std::forward_as_tuple(id, factory, _node_map));
+        Node<MatFwd, MatIn, MatEmb, ModelT>& root_node = placeholder.first->second;
 
         if (!placeholder.second) // already exists
-          return root_node;
+          return id;
 
         th::Table* root_data = th::get_field<th::Table*>(root_fields, "data");
         th::Class* module_class = th::get_field<th::Class*>(root_data, "module");
         if (!module_class)
-          root_node.set_module(nullptr);
+          root_node.set_module_id(std::numeric_limits<size_t>::max());
         else
-          root_node.set_module(factory.build(module_class));
+          root_node.set_module_id(factory.build(module_class));
         th::Number* selectindex = th::get_field<th::Number*>(root_data, "selectindex");
         if (selectindex)
           root_node.set_select_index(static_cast<int>(selectindex->get_value())-1);
         th::Table* mapindex = th::get_field<th::Table*>(root_data, "mapindex");
 
-        for (auto it = mapindex->get_array().begin(); it != mapindex->get_array().end(); it++)
+        for (auto it = mapindex->get_array().begin(); it != mapindex->get_array().end(); ++it)
         {
           th::Table* data = dynamic_cast<th::Table*>(*it);
           if (data)
@@ -106,17 +130,17 @@ namespace onmt
 
         if (children)
         {
-          for (auto it = children->get_array().begin(); it != children->get_array().end(); it++)
+          for (auto it = children->get_array().begin(); it != children->get_array().end(); ++it)
           {
             if ((*it)->type() == th::ObjType::TORCH)
             {
-              Node<MatFwd>& child = build_graph(*it, factory);
+              size_t child = build_graph(*it, factory);
               root_node.add_child(child);
             }
           }
         }
 
-        return root_node;
+        return id;
       }
     };
 

--- a/include/onmt/nn/Identity.h
+++ b/include/onmt/nn/Identity.h
@@ -7,13 +7,23 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class Identity: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class Identity: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       Identity()
-        : Module<MatFwd>("nn.Identity")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.Identity")
       {
+      }
+
+      Identity(const Identity& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new Identity(*this);
       }
 
       void forward_impl(const std::vector<MatFwd>& inputs) override

--- a/include/onmt/nn/JoinTable.h
+++ b/include/onmt/nn/JoinTable.h
@@ -7,13 +7,23 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class JoinTable: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class JoinTable: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       JoinTable()
-        : Module<MatFwd>("nn.JoinTable")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.JoinTable")
       {
+      }
+
+      JoinTable(const JoinTable& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new JoinTable(*this);
       }
 
       void forward_impl(const std::vector<MatFwd>& inputs) override

--- a/include/onmt/nn/Linear.h
+++ b/include/onmt/nn/Linear.h
@@ -42,7 +42,7 @@ namespace onmt
       {
       }
 
-      virtual Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
       {
         return new Linear(*this);
       }

--- a/include/onmt/nn/LogSoftMax.h
+++ b/include/onmt/nn/LogSoftMax.h
@@ -7,13 +7,23 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class LogSoftMax: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class LogSoftMax: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       LogSoftMax()
-        : Module<MatFwd>("nn.LogSoftMax")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.LogSoftMax")
       {
+      }
+
+      LogSoftMax(const LogSoftMax& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new LogSoftMax(*this);
       }
 
       void forward_impl(const MatFwd& input)

--- a/include/onmt/nn/LookupTable.h
+++ b/include/onmt/nn/LookupTable.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include "onmt/nn/Module.h"
 #include "onmt/th/Obj.h"
 #include "onmt/StorageLoader.h"
@@ -9,26 +10,37 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd, typename MatEmb, typename ModelT>
-    class LookupTable: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class LookupTable: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       LookupTable(th::Table* data)
-        : Module<MatFwd>("nn.LookupTable")
-        , _weight(StorageLoader<MatEmb, ModelT>::get_matrix(data, "weight"))
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.LookupTable")
+        , _weight(new MatEmb(StorageLoader<MatEmb, ModelT>::get_matrix(data, "weight")))
       {
+      }
+
+      LookupTable(const LookupTable& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _weight(other._weight)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new LookupTable(*this);
       }
 
       void forward_impl(const MatFwd& input) override
       {
-        this->_output.resize(input.rows(), _weight.cols());
+        this->_output.resize(input.rows(), _weight->cols());
 
         for (size_t i = 0; i < input.batches(); ++i)
-          this->_output.row(i).noalias() = _weight.row(input(i, 0));
+          this->_output.row(i).noalias() = _weight->row(input(i, 0));
       }
 
     private:
-      MatEmb _weight;
+      std::shared_ptr<MatEmb> _weight;
     };
 
   }

--- a/include/onmt/nn/MM.h
+++ b/include/onmt/nn/MM.h
@@ -7,15 +7,27 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class MM: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class MM: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       MM(th::Table* data)
-        : Module<MatFwd>("nn.MM")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.MM")
         , _transA(get_boolean(data, "transA"))
         , _transB(get_boolean(data, "transB"))
       {
+      }
+
+      MM(const MM& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _transA(other._transA)
+        , _transB(other._transB)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new MM(*this);
       }
 
       void forward_impl(const std::vector<MatFwd>& inputs) override

--- a/include/onmt/nn/ModuleFactory.h
+++ b/include/onmt/nn/ModuleFactory.h
@@ -17,13 +17,16 @@ namespace onmt
     {
     public:
       ModuleFactory(Profiler& profiler, bool cuda, bool qlinear);
+      ModuleFactory(const ModuleFactory& other);
       ~ModuleFactory();
 
-      Module<MatFwd>* build(th::Class* obj);
+      size_t build(th::Class* obj);
+      Module<MatFwd, MatIn, MatEmb, ModelT>* get_module(size_t id) const;
+      void set_profiler(Profiler& profiler);
 
     private:
-      std::vector<Module<MatFwd>*> _storage;
-      Profiler& _profiler;
+      std::vector<Module<MatFwd, MatIn, MatEmb, ModelT>*> _storage;
+      Profiler* _profiler;
       bool _cuda;
       bool _qlinear;
 #ifdef WITH_CUDA

--- a/include/onmt/nn/ModuleFactory.hxx
+++ b/include/onmt/nn/ModuleFactory.hxx
@@ -40,10 +40,9 @@ namespace onmt
   namespace nn
   {
 
-
     template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
     ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>::ModuleFactory(Profiler& profiler, bool cuda, bool qlinear)
-      : _profiler(profiler)
+      : _profiler(&profiler)
       , _cuda(cuda)
       , _qlinear(qlinear)
     {
@@ -64,6 +63,41 @@ namespace onmt
     }
 
     template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>::ModuleFactory(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& other)
+      : _profiler(nullptr)
+      , _cuda(other._cuda)
+      , _qlinear(other._qlinear)
+    {
+      if (_cuda)
+      {
+#ifdef WITH_CUDA
+        CUBLAS_CHECK(cublasCreate(&_handle));
+#else
+        throw std::runtime_error("CTranslate was not compiled with CUDA support");
+#endif
+      }
+      if (_qlinear)
+      {
+#ifndef WITH_QLINEAR
+        throw std::runtime_error("CTranslate was not compiled with QLINEAR support");
+#endif
+      }
+
+      for (const auto& mod: other._storage)
+      {
+        _storage.push_back(mod->clone(this));
+#ifdef WITH_CUDA
+        if (_cuda)
+        {
+          auto cul = dynamic_cast<cuLinear<MatFwd, MatIn, MatEmb, ModelT>*>(_storage.back());
+          if (cul)
+            cul->set_handle(&_handle);
+        }
+#endif
+      }
+    }
+
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
     ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>::~ModuleFactory()
     {
 #ifdef WITH_CUDA
@@ -76,60 +110,60 @@ namespace onmt
     }
 
     template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
-    Module<MatFwd>*
+    size_t
     ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>::build(th::Class* obj)
     {
       std::string name = obj->get_classname();
       auto data = dynamic_cast<th::Table*>(obj->get_data());
 
-      Module<MatFwd>* mod = nullptr;
+      Module<MatFwd, MatIn, MatEmb, ModelT>* mod = nullptr;
 
       if (name == "nn.Linear")
       {
 #ifdef WITH_CUDA
         if (_cuda)
-          mod = new cuLinear<MatFwd, MatIn, ModelT>(data, _handle);
+          mod = new cuLinear<MatFwd, MatIn, MatEmb, ModelT>(data, &_handle);
         else
 #endif
 #ifdef WITH_QLINEAR
         if (_qlinear)
-          mod = new qLinear<MatFwd, MatIn, ModelT>(data);
+          mod = new qLinear<MatFwd, MatIn, MatEmb, ModelT>(data);
         else
 #endif
-          mod = new Linear<MatFwd, MatIn, ModelT>(data);
+          mod = new Linear<MatFwd, MatIn, MatEmb, ModelT>(data);
       }
       else if (name == "nn.LookupTable")
-        mod =  new LookupTable<MatFwd, MatEmb, ModelT>(data);
+        mod =  new LookupTable<MatFwd, MatIn, MatEmb, ModelT>(data);
       else if (name == "nn.CAddTable")
-        mod = new CAddTable<MatFwd>();
+        mod = new CAddTable<MatFwd, MatIn, MatEmb, ModelT>();
       else if (name == "nn.CMulTable")
-        mod = new CMulTable<MatFwd>();
+        mod = new CMulTable<MatFwd, MatIn, MatEmb, ModelT>();
       else if (name == "nn.Sigmoid")
-        mod = new Sigmoid<MatFwd>();
+        mod = new Sigmoid<MatFwd, MatIn, MatEmb, ModelT>();
       else if (name == "nn.Tanh")
-        mod = new Tanh<MatFwd>();
+        mod = new Tanh<MatFwd, MatIn, MatEmb, ModelT>();
       else if (name == "nn.SplitTable")
-        mod = new SplitTable<MatFwd>();
+        mod = new SplitTable<MatFwd, MatIn, MatEmb, ModelT>();
       else if (name == "nn.JoinTable")
-        mod = new JoinTable<MatFwd>();
+        mod = new JoinTable<MatFwd, MatIn, MatEmb, ModelT>();
       else if (name == "nn.SelectTable")
-        mod = new SelectTable<MatFwd>(data);
+        mod = new SelectTable<MatFwd, MatIn, MatEmb, ModelT>(data);
       else if (name == "nn.Reshape")
-        mod = new Reshape<MatFwd>(data);
+        mod = new Reshape<MatFwd, MatIn, MatEmb, ModelT>(data);
       else if (name == "nn.Replicate")
-        mod = new Replicate<MatFwd>(data);
+        mod = new Replicate<MatFwd, MatIn, MatEmb, ModelT>(data);
       else if (name == "nn.SoftMax")
-        mod = new SoftMax<MatFwd>();
+        mod = new SoftMax<MatFwd, MatIn, MatEmb, ModelT>();
       else if (name == "nn.LogSoftMax")
-        mod = new LogSoftMax<MatFwd>();
+        mod = new LogSoftMax<MatFwd, MatIn, MatEmb, ModelT>();
       else if (name == "nn.MM")
-        mod = new MM<MatFwd>(data);
+        mod = new MM<MatFwd, MatIn, MatEmb, ModelT>(data);
       else if (name == "nn.Sum")
-        mod = new Sum<MatFwd>(data);
+        mod = new Sum<MatFwd, MatIn, MatEmb, ModelT>(data);
       else if (name == "nn.Squeeze")
-        mod = new Squeeze<MatFwd>(data);
+        mod = new Squeeze<MatFwd, MatIn, MatEmb, ModelT>(data);
       else if (name == "nn.MulConstant")
-        mod = new MulConstant<MatFwd, ModelT>(data);
+        mod = new MulConstant<MatFwd, MatIn, MatEmb, ModelT>(data);
       else if (name == "nn.Sequential")
         mod = new Sequential<MatFwd, MatIn, MatEmb, ModelT>(data, *this);
       else if (name == "nn.ConcatTable")
@@ -137,7 +171,7 @@ namespace onmt
       else if (name == "nn.ParallelTable")
         mod = new ParallelTable<MatFwd, MatIn, MatEmb, ModelT>(data, *this);
       else if (name == "nn.Identity" || name == "nn.Dropout")
-        mod = new Identity<MatFwd>();
+        mod = new Identity<MatFwd, MatIn, MatEmb, ModelT>();
       else if (name == "nn.gModule")
         mod = new Graph<MatFwd, MatIn, MatEmb, ModelT>(obj, name, *this);
       else
@@ -157,9 +191,25 @@ namespace onmt
 
       mod->set_profiler(_profiler);
 
+      size_t id = _storage.size();
       _storage.push_back(mod);
 
-      return mod;
+      return id;
+    }
+
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    Module<MatFwd, MatIn, MatEmb, ModelT>*
+    ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>::get_module(size_t id) const
+    {
+      return _storage.at(id);
+    }
+
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    void ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>::set_profiler(Profiler& profiler)
+    {
+      _profiler = &profiler;
+      for (auto& mod : _storage)
+        mod->set_profiler(_profiler);
     }
 
   }

--- a/include/onmt/nn/MulConstant.h
+++ b/include/onmt/nn/MulConstant.h
@@ -7,14 +7,25 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd, typename ModelT>
-    class MulConstant: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class MulConstant: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       MulConstant(th::Table* data)
-        : Module<MatFwd>("nn.MulConstant")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.MulConstant")
         , _scalar(th::get_scalar<ModelT>(data, "constant_scalar"))
       {
+      }
+
+      MulConstant(const MulConstant& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _scalar(other._scalar)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new MulConstant(*this);
       }
 
       void forward_impl(const MatFwd& input)

--- a/include/onmt/nn/ParallelTable.h
+++ b/include/onmt/nn/ParallelTable.h
@@ -16,36 +16,48 @@ namespace onmt
       {
       }
 
+      ParallelTable(const ParallelTable& other,
+                    const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory)
+        : Container<MatFwd, MatIn, MatEmb, ModelT>(other, factory)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>* factory) const override
+      {
+        return new ParallelTable(*this, *factory);
+      }
+
       void forward_impl(const std::vector<MatFwd>& inputs) override
       {
-        this->_outputs.resize(this->_sequence.size());
+        this->_outputs.resize(this->_sequence->size());
 
-        for (size_t i = 0; i < this->_sequence.size(); ++i)
+        for (size_t i = 0; i < this->_sequence->size(); ++i)
         {
-          if (inputs.size() == 1 && this->_sequence.size() > 1)
+          auto mod = this->_factory.get_module((*(this->_sequence))[i]);
+          if (inputs.size() == 1 && this->_sequence->size() > 1)
           {
             // This is a special case when the inputs table is actually bundled in a single matrix.
             // The dimensions that do not have a corresponding module are all forwarded to the
             // last module in the sequence.
-            if (i == this->_sequence.size() - 1)
+            if (i == this->_sequence->size() - 1)
             {
               std::vector<MatFwd> in;
               for (int j = i; j < inputs[0].cols(); ++j)
                 in.push_back(inputs[0].col(j));
 
-              auto res = this->_sequence[i]->forward(in);
+              auto res = mod->forward(in);
 
               for (size_t j = i; j - i < res.size(); ++j)
                 this->_outputs[j] = res[j - i];
             }
             else
             {
-              this->_outputs[i] = this->_sequence[i]->forward_one(inputs[0].col(i));
+              this->_outputs[i] = mod->forward_one(inputs[0].col(i));
             }
           }
           else
           {
-            this->_outputs[i] = this->_sequence[i]->forward_one(inputs[i]);
+            this->_outputs[i] = mod->forward_one(inputs[i]);
           }
         }
       }

--- a/include/onmt/nn/Replicate.h
+++ b/include/onmt/nn/Replicate.h
@@ -9,15 +9,27 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class Replicate: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class Replicate: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       Replicate(th::Table* data)
-        : Module<MatFwd>("nn.Replicate")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.Replicate")
         , _dimension(th::get_number(data, "dim"))
         , _nfeatures(th::get_number(data, "nfeatures"))
       {
+      }
+
+      Replicate(const Replicate& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _dimension(other._dimension)
+        , _nfeatures(other._nfeatures)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new Replicate(*this);
       }
 
       void forward_impl(const MatFwd& input) override

--- a/include/onmt/nn/Reshape.h
+++ b/include/onmt/nn/Reshape.h
@@ -7,14 +7,25 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class Reshape: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class Reshape: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       Reshape(th::Table* data)
-        : Module<MatFwd>("nn.Reshape")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.Reshape")
         , _dims(th::get_storage_as_vector<long>(data, "size"))
       {
+      }
+
+      Reshape(const Reshape& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _dims(other._dims)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new Reshape(*this);
       }
 
       void forward_impl(const std::vector<MatFwd>& inputs) override

--- a/include/onmt/nn/SelectTable.h
+++ b/include/onmt/nn/SelectTable.h
@@ -9,14 +9,25 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class SelectTable: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class SelectTable: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       SelectTable(th::Table* data)
-        : Module<MatFwd>("nn.SelectTable")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.SelectTable")
         , _index(th::get_number(data, "index"))
       {
+      }
+
+      SelectTable(const SelectTable& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _index(other._index)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new SelectTable(*this);
       }
 
       void forward_impl(const std::vector<MatFwd>& inputs) override

--- a/include/onmt/nn/Sequential.h
+++ b/include/onmt/nn/Sequential.h
@@ -16,20 +16,31 @@ namespace onmt
       {
       }
 
+      Sequential(const Sequential& other,
+                 const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>& factory)
+        : Container<MatFwd, MatIn, MatEmb, ModelT>(other, factory)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>* factory) const override
+      {
+        return new Sequential(*this, *factory);
+      }
+
       void forward_impl(const std::vector<MatFwd>& inputs) override
       {
-        if (this->_sequence.empty())
+        if (this->_sequence->empty())
         {
           this->_outputs = inputs;
           return;
         }
 
-        auto it = this->_sequence.begin();
-        this->_outputs = (*it)->forward(inputs);
+        auto it = this->_sequence->begin();
+        this->_outputs = this->_factory.get_module(*it)->forward(inputs);
 
-        for (it++; it != this->_sequence.end(); it++)
+        for (it++; it != this->_sequence->end(); it++)
         {
-          this->_outputs = (*it)->forward(this->_outputs);
+          this->_outputs = this->_factory.get_module(*it)->forward(this->_outputs);
         }
       }
     };

--- a/include/onmt/nn/Sigmoid.h
+++ b/include/onmt/nn/Sigmoid.h
@@ -7,13 +7,23 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class Sigmoid: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class Sigmoid: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       Sigmoid()
-        : Module<MatFwd>("nn.Sigmoid")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.Sigmoid")
       {
+      }
+
+      Sigmoid(const Sigmoid& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new Sigmoid(*this);
       }
 
       void forward_impl(const MatFwd& input) override

--- a/include/onmt/nn/SoftMax.h
+++ b/include/onmt/nn/SoftMax.h
@@ -7,13 +7,23 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class SoftMax: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class SoftMax: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       SoftMax()
-        : Module<MatFwd>("nn.SoftMax")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.SoftMax")
       {
+      }
+
+      SoftMax(const SoftMax& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new SoftMax(*this);
       }
 
       void forward_impl(const MatFwd& input)

--- a/include/onmt/nn/SplitTable.h
+++ b/include/onmt/nn/SplitTable.h
@@ -7,13 +7,23 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class SplitTable: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class SplitTable: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       SplitTable()
-        : Module<MatFwd>("nn.SplitTable")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.SplitTable")
       {
+      }
+
+      SplitTable(const SplitTable& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new SplitTable(*this);
       }
 
       void forward_impl(const std::vector<MatFwd>& inputs) override

--- a/include/onmt/nn/Squeeze.h
+++ b/include/onmt/nn/Squeeze.h
@@ -8,14 +8,25 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class Squeeze: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class Squeeze: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       Squeeze(th::Table* data)
-        : Module<MatFwd>("nn.Squeeze")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.Squeeze")
         , _dimension(get_number(data, "dimension"))
       {
+      }
+
+      Squeeze(const Squeeze& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _dimension(other._dimension)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new Squeeze(*this);
       }
 
       void forward_impl(const MatFwd& input) override

--- a/include/onmt/nn/Sum.h
+++ b/include/onmt/nn/Sum.h
@@ -8,14 +8,25 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class Sum: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class Sum: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       Sum(th::Table* data)
-        : Module<MatFwd>("nn.Sum")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.Sum")
         , _dimension(get_number(data, "dimension"))
       {
+      }
+
+      Sum(const Sum& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _dimension(other._dimension)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new Sum(*this);
       }
 
       void forward_impl(const MatFwd& input) override

--- a/include/onmt/nn/Tanh.h
+++ b/include/onmt/nn/Tanh.h
@@ -7,13 +7,23 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd>
-    class Tanh: public Module<MatFwd>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class Tanh: public Module<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       Tanh()
-        : Module<MatFwd>("nn.Tanh")
+        : Module<MatFwd, MatIn, MatEmb, ModelT>("nn.Tanh")
       {
+      }
+
+      Tanh(const Tanh& other)
+        : Module<MatFwd, MatIn, MatEmb, ModelT>(other)
+      {
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new Tanh(*this);
       }
 
       void forward_impl(const MatFwd& input) override

--- a/include/onmt/nn/qLinear.h
+++ b/include/onmt/nn/qLinear.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <cstdlib>
 #include "onmt/nn/Linear.h"
 #include "onmt/th/Obj.h"
 #include "onmt/Utils.h"
@@ -11,42 +12,59 @@ namespace onmt
   namespace nn
   {
 
-    template <typename MatFwd, typename MatIn, typename ModelT>
-    class qLinear: public Linear<MatFwd, MatIn, ModelT>
+    template <typename MatFwd, typename MatIn, typename MatEmb, typename ModelT>
+    class qLinear: public Linear<MatFwd, MatIn, MatEmb, ModelT>
     {
     public:
       qLinear(th::Table* data)
-        : Linear<MatFwd, MatIn, ModelT>(data), _quant_input_buffer(nullptr)
+        : Linear<MatFwd, MatIn, MatEmb, ModelT>(data)
+        , _quant_weight_buffer(_malloc_align(_quant_weight, this->_wrows * this->_wcols / SIMD_VSIZE),
+          [](void* p) { std::free(p); })
+        , _quant_input_buffer(nullptr)
       {
         // Quantize the weight - ncols=width is supposed to be multiple of SIMD_VSIZE
         if (this->_wcols % SIMD_VSIZE)
           throw std::runtime_error("Weight matrix width should be multiple of 8/16 for qLinear");
-        _malloc_align(_quant_weight_buffer, _quant_weight, this->_wrows * this->_wcols / SIMD_VSIZE);
-        simd::Quantize(this->_weight.data(), _quant_weight, this->_wrows, this->_wcols);
+        simd::Quantize(this->_weight->data(), _quant_weight, this->_wrows, this->_wcols);
+      }
+
+      qLinear(const qLinear& other)
+        : Linear<MatFwd, MatIn, MatEmb, ModelT>(other)
+        , _quant_weight_buffer(other._quant_weight_buffer)
+        , _quant_input_buffer(nullptr)
+        , _quant_weight(other._quant_weight)
+      {
       }
 
       virtual ~qLinear()
       {
-        free(_quant_weight_buffer);
-        free(_quant_input_buffer);
+        std::free(_quant_input_buffer);
+      }
+
+      Module<MatFwd, MatIn, MatEmb, ModelT>* clone(const ModuleFactory<MatFwd, MatIn, MatEmb, ModelT>*) const override
+      {
+        return new qLinear(*this);
       }
 
       /* aligned allocation method - in c++17 we have aligned_alloc that we can use */
-      void _malloc_align(void *&buffer, SIMD_TYPE *&data, size_t size)
+      void* _malloc_align(SIMD_TYPE *&data, size_t size)
       {
-        buffer = nullptr;
-        _realloc_align(buffer, data, size);
+        return _realloc_align(nullptr, data, size);
       }
 
-      void _realloc_align(void *&buffer, SIMD_TYPE *&data, size_t size)
+      void* _realloc_align(void *buffer, SIMD_TYPE *&data, size_t size)
       {
         size_t buf_size = (size + 1) * sizeof(SIMD_TYPE);
-        buffer = realloc(buffer, buf_size);
-        if (!buffer)
+        void* p = std::realloc(buffer, buf_size);
+        if (!p)
+        {
+          std::free(buffer);
           throw std::runtime_error("Cannot allocate memory");
-        void* ptr = (void*)buffer;
+        }
+        void* ptr = p;
         align(sizeof(SIMD_TYPE), size * sizeof(SIMD_TYPE), ptr, buf_size);
         data = reinterpret_cast<SIMD_TYPE*>(ptr);
+        return p;
       }
 
       virtual void forward_impl(const MatFwd& input) override
@@ -57,22 +75,22 @@ namespace onmt
           this->_output.resize(input.rows(), this->_wrows);
 
         /* quantize the input */
-        _realloc_align(_quant_input_buffer, _quant_input, input.rows() * input.cols() / SIMD_VSIZE);
+        _quant_input_buffer = _realloc_align(_quant_input_buffer, _quant_input, input.rows() * input.cols() / SIMD_VSIZE);
         simd::Quantize(input.data(), _quant_input, input.rows(), input.cols());
 
         simd::MatrixMult(_quant_input, _quant_weight, this->_output.data(),
-                         input.rows(), (this->_rwrows?this->_rwrows:this->_wrows), this->_wcols,
+                         input.rows(), (this->_rwrows ? this->_rwrows : this->_wrows), this->_wcols,
                          _subdict);
 
         /* add bias */
-        if (this->_bias.rows() > 0)
+        if (this->_bias->rows() > 0)
         {
           if (this->_rwrows)
             for (int i = 0; i < input.rows(); ++i)
               this->_output.row(i).noalias() += this->_rbias.transpose();
           else
             for (int i = 0; i < input.rows(); ++i)
-              this->_output.row(i).noalias() += this->_bias.transpose();
+              this->_output.row(i).noalias() += this->_bias->transpose();
         }
       }
 
@@ -84,12 +102,12 @@ namespace onmt
         this->_rbias.resize(v.size(), 1);
         /* adjust bias */
         for (size_t i = 0; i < v.size(); i++) {
-          this->_rbias.row(i) = this->_bias.row(v[i]);
+          this->_rbias.row(i) = this->_bias->row(v[i]);
         }
       }
 
     protected:
-      void* _quant_weight_buffer;
+      std::shared_ptr<void> _quant_weight_buffer;
       void* _quant_input_buffer;
       SIMD_TYPE* _quant_weight;
       SIMD_TYPE* _quant_input;


### PR DESCRIPTION
When using CUDA or QLINEAR, weights and biases are duplicated when the translator object is cloned. This results in very high memory usage. This PR makes the weights and biases, which remain constant, be shared, and in so doing, keeps the memory usage for multiple translator objects down. The change here does this by using shared pointers on weight and bias for the Linear modules, and by using IDs for factory modules, making it easy to copy construct a new module factory.